### PR TITLE
Lightos finish processing photos before teardown

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-camera",
-  "version": "4.6.5",
+  "version": "4.6.6",
   "description": "A powerful, high-performance React Native Camera library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## What

This PR addresses the problem from [this ticket](https://github.com/sanctuarycomputer/light-two/issues/9090): processing a photo takes ~2-5 seconds. If a user closes the camera (by entering the gallery for e.g.) then the camera is torn down, processing interrupted and the photo never gets saved.

This now increases the CameraSession lifecycle so it doesn't get torn down until after any pending photos have finished processing or a timeout (currently 5 seconds) is reached. This has to be done on a background thread otherwise the camera UI freezes until processing is finished.

## To Test

- Update the RNVC version in /LightOS/package.json to v4.6.6
- `yarn install`, `yarn run-lp3` etc
- Open logcat and filter for `LP3_Camera`
- Take a photo or two and navigate away from the camera (press the home button, gallery button, photo menu etc etc)
- You should still see the photos being processed in the background in logcat

## Concerns

This is not a perfect solution and probably needs some more thought. Issues:
- It doesn't account for this use case: user takes a photo, presses the "photo menu" button and reenters photo mode. In this case the processing queue is reset and the photo being processed is lost.
- If the user enters the gallery before the photo has finished processing, the photo won't show up until they refresh (after processing completes). This is likely a common scenario and is captured in [this ticket](https://github.com/sanctuarycomputer/light-two/issues/9091)

