### PR TITLE
Returning photo mediastore Uri

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
@@ -116,7 +116,10 @@ suspend fun CameraSession.takePhoto(options: TakePhotoOptions): Photo = suspendC
         put(MediaStore.Images.Media.DATE_TAKEN, capturedAt)
         put(MediaStore.Images.Media.DATA, outputFile.absolutePath)
       }
-      context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+
+      // we want to return the contentUri so the frontend can handle it through the mediastore
+      val mediaUri = context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+      returnVal.path = mediaUri.toString()
 
       if (options.resolveOnCaptureStarted && continuation.isActive) {
         // resolve the promise

--- a/package/android/src/main/java/com/mrousavy/camera/core/Photo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/Photo.kt
@@ -2,4 +2,4 @@ package com.mrousavy.camera.core
 
 import com.mrousavy.camera.core.types.Orientation
 
-data class Photo(val path: String, val width: Int, val height: Int, val orientation: Orientation, val isMirrored: Boolean)
+data class Photo(var path: String, val width: Int, val height: Int, val orientation: Orientation, val isMirrored: Boolean)

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-camera",
-  "version": "4.6.11",
+  "version": "4.6.12",
   "description": "A powerful, high-performance React Native Camera library.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

We want the media store content uri from the taken photo instead of the full path. The uri makes it easier for us to delete the photo if it's unwanted, specifically when attaching a photo and not wanting to keep it.


<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->

## Changes

<!--
  Create a short list of logic-changes.
  Examples:
    * This PR changes the default value of X to Y.
    * This PR changes the configure() function to cache results.
-->

## Tested on

<!--
  Create a short list of devices and operating-systems you have tested this change on. (And verified that everything works as expected).
  Examples:
    * iPhone 11 Pro, iOS 14.3
    * Huawai P20, Android 10
-->

## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
