### PR TITLE
readd shutter callback

### DIFF
--- a/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
+++ b/package/android/src/main/java/com/mrousavy/camera/core/CameraSession+Photo.kt
@@ -121,6 +121,8 @@ suspend fun CameraSession.takePhoto(options: TakePhotoOptions): Photo = suspendC
       val mediaUri = context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
       returnVal.path = mediaUri.toString()
 
+      callback.onShutter(ShutterType.PHOTO)
+
       if (options.resolveOnCaptureStarted && continuation.isActive) {
         // resolve the promise
           continuation.resume(returnVal)


### PR DESCRIPTION
<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What

This readds the shutter callback being called onCaptureStarted which allows us to use the `onShutter` callback in `<Camera>`
<!--
  Enter a short description on what this pull-request does.
  Examples:
    This PR adds support for the HEVC format.
    This PR fixes a "unsupported device" error on iPhone 8 and below.
    This PR fixes a typo in a CameraError.
    This PR adds support for Quadruple Cameras.
-->
